### PR TITLE
check if token register exists using allocation number

### DIFF
--- a/src/luaotfload-colors.lua
+++ b/src/luaotfload-colors.lua
@@ -321,9 +321,10 @@ local color_handler = function (head)
     if res then
         res["1"]  = true
         local tpr = texget("pdfpageresources")
-        local pgf_loaded = tpr:find("/ExtGState %d+ 0 R")
+        local no_extgs = not tpr:find("/ExtGState<<.*>>")
+        local pgf_loaded = no_extgs and luaotfload.pgf_loaded
         if pgf_loaded then
-            tpr = texgettoks("pgf@sys@pgf@resource@list@extgs@toks") -- see luaotfload.sty
+            tpr = texgettoks(pgf_loaded) -- see luaotfload.sty
         end
 
         local t   = ""
@@ -335,9 +336,9 @@ local color_handler = function (head)
         end
         if t ~= "" then
             if pgf_loaded then
-                texsettoks("global", "pgf@sys@pgf@resource@list@extgs@toks", tpr..t)
+                texsettoks("global", pgf_loaded, tpr..t)
             else
-                if not tpr:find("/ExtGState<<.*>>") then
+                if no_extgs then
                     tpr = tpr .. "/ExtGState<<>>"
                 end
                 tpr = tpr:gsub("/ExtGState<<", "%1"..t)

--- a/src/luaotfload.sty
+++ b/src/luaotfload.sty
@@ -50,6 +50,7 @@
 \ifcsname selectfont\endcsname
   \AtBeginDocument{\@ifpackageloaded{pgfsys}{
     \csname newtoks\endcsname\pgf@sys@pgf@resource@list@extgs@toks
+    \directlua{luaotfload.pgf_loaded=\the\allocationnumber}
     \def\pgf@sys@pgf@resource@list@extgs{\the\pgf@sys@pgf@resource@list@extgs@toks}
     \def\pgf@sys@addpdfresource@extgs@plain#1{\global\pgf@sys@pgf@resource@list@extgs@toks
       \expandafter{\the\pgf@sys@pgf@resource@list@extgs@toks #1}}
@@ -60,6 +61,7 @@
 \count255=\the\catcode`@\relax
 \catcode`@=11\relax
 \newtoks\pgf@sys@pgf@resource@list@extgs@toks
+\directlua{luaotfload.pgf_loaded=\the\allocationnumber}
 \def\pgf@sys@pgf@resource@list@extgs{\the\pgf@sys@pgf@resource@list@extgs@toks}
 \def\pgf@sys@addpdfresource@extgs@plain#1{\global\pgf@sys@pgf@resource@list@extgs@toks
   \expandafter{\the\pgf@sys@pgf@resource@list@extgs@toks #1}}


### PR DESCRIPTION
If some other third party package had declared an ExtGState pdf object, current code fails at checking the existence of pgf token register and we get an error. This patch addresses this issue.  
